### PR TITLE
Bug fix

### DIFF
--- a/more_functions/exercises.ml
+++ b/more_functions/exercises.ml
@@ -1,18 +1,18 @@
-let todo = failwith "unimplemented"
+let todo () = failwith "unimplemented"
 
 (* Exercise: Compose*)
-let compose = todo
+let compose = todo ()
 
 (* Exercise: Power of Fold *)
 
 (* Function length takes in a list and returns it's length*)
-let length = todo
+let length = todo ()
 
 (* Function rev reverses a given list *)
-let rev = todo
+let rev = todo ()
 
 (* Map takes in a function f, list l and applies f to each element in l*)
-let map = todo
+let map = todo ()
 
 (* Filter removes the elements that doesn't safisy the given precidate f*)
-let filter = todo
+let filter = todo ()

--- a/recursive_functions/exercises.ml
+++ b/recursive_functions/exercises.ml
@@ -1,16 +1,16 @@
-let todo = failwith "unimplemented"
+let todo () = failwith "unimplemented"
 
 (* Exercise: Sum *)
-let rec sum : int = todo
+let rec sum : int = todo ()
 
 (* Exercise: Sum Tail Recursive *)
-let rec sum_tail : int = todo
+let rec sum_tail : int = todo ()
 
 (* Exercise: takeWhile*)
-let rec takeWhile  = todo
+let rec takeWhile  = todo ()
 
 (*Exercise: Fib Fast*)
-let rec fib_fast : int = todo
+let rec fib_fast : int = todo ()
 
 (*Exercise: Function Associativity *)
 let add (a: int) (b: int) : int = a + b

--- a/recursive_functions/test.ml
+++ b/recursive_functions/test.ml
@@ -8,26 +8,26 @@ let assert_int_list_equal l1 l2 = assert_equal ~printer:string_of_int_list l1 l2
 let sum_tests = 
   "test sum functions"
    >::: [
-     ("" >:: fun _ -> assert_equal (sum [1; 2; 3] 5));
-     ("" >:: fun _ -> assert_equal (sum_tail [1; 2; 3] 5));
+     ("" >:: fun _ -> assert_equal (sum [1; 2; 3]) 6);
+     ("" >:: fun _ -> assert_equal (sum_tail [1; 2; 3]) 6);
    ]
 
 let take_while_test = 
   "test takeWhile"
   >::: [
-    ("" > fun _ -> assert_int_list_equal
+    ("" >:: fun _ -> assert_int_list_equal
      (takeWhile (fun x -> x < 4) [1; 2; 3; 4; 5; 3; 2])
-     [1, 2, 3]);
-    ("" > fun _ -> assert_int_list_equal
+     [1; 2; 3]);
+    ("" >:: fun _ -> assert_int_list_equal
      (takeWhile (fun x -> x < 4) [1; 2; 3])
-     [1, 2, 3]);
-    ("" > fun _ -> assert_int_list_equal
+     [1; 2; 3]);
+    ("" >:: fun _ -> assert_int_list_equal
      (takeWhile (fun x -> x < 4) [5; 6; 7])
      []);
-    ("" > fun _ -> assert_int_list_equal
+    ("" >:: fun _ -> assert_int_list_equal
      (takeWhile (fun x -> x < 4) [])
      []);
-    ("" > fun _ -> assert_int_list_equal
+    ("" >:: fun _ -> assert_int_list_equal
      (takeWhile (fun x -> x < 4) [5; 3; 2; 1])
      []);
   ]
@@ -35,9 +35,11 @@ let take_while_test =
 let fib_fast_test = 
   "test fib_fast"
   >::: [
-    ("" > fun _ -> assert_equal (fib_fast 5) 3);
-    ("" > fun _ -> assert_equal (fib_fast 0) 1);
+    ("" >:: fun _ -> assert_equal (fib_fast 6) 8);
+    ("" >:: fun _ -> assert_equal (fib_fast 4) 3);
+    ("" >:: fun _ -> assert_equal (fib_fast 0) 0);
   ]
+
 
   let suite = "suite" >::: [ sum_tests; take_while_test; fib_fast_test]
   let () = run_test_tt_main suite

--- a/testing/test.ml
+++ b/testing/test.ml
@@ -29,7 +29,7 @@ not cover this case. [OUnit2] provides [assert_raises] for this purpose.
 The second argument to [assert_raises] must be a function from [unit].
 The function body is the actual program that we want to test. *)
 
-let test_head =
+let suite =
   "head"
   >::: [
          ("empty" >:: fun _ -> assert_raises Not_found (fun _ -> head []));
@@ -60,4 +60,4 @@ let rec index_of : 'a -> 'a list -> int =
 
 let test_index_of = "index_of" >::: []
 
-let () = run_test_tt_main ("test" >::: [ test_head; test_index_of ])
+let () = run_test_tt_main (test_index_of)

--- a/tuples_records_and_adts/exercises.ml
+++ b/tuples_records_and_adts/exercises.ml
@@ -1,25 +1,25 @@
 #use "demo.ml"
-let todo = failwith "unimplemented"
+let todo () = failwith "unimplemented"
 
 (* Exercise: Languages *)
 (* Your Implementation Goes Here *)
 
 (* Exercise: Map and Fold_left *)
-let rec map : mylist = todo
-let rec foldl : ('b 'a -> 'b) * 'a * 'a mylist -> 'b = todo 
+let rec map : mylist = todo ()
+let rec foldl : ('b 'a -> 'b) * 'a * 'a mylist -> 'b = todo () 
 
 (* Exercise: Custom Trees *) 
 
-type tree = todo
+type tree = todo ()
 
 (* Exercise: Sentence to Tree *)
-let sentence_to_tree (s: string list) = todo
+let sentence_to_tree (s: string list) = todo ()
 
 (* Exercise: Traverse & Collapse *)
-let tree_traverse = todo
+let tree_traverse = todo ()
 
 (* Exercise: Depth *)
-let depth = todo
+let depth = todo ()
 
 (* Exercise: Is BST? *)
-let  is_bst = todo
+let  is_bst = todo ()


### PR DESCRIPTION
* `todo` --> `todo ()`. so that students don't need to comment out `let todo ...` before `dune test`. Sinan, I think we should generally avoid this in future labs.
* consistently naming test suites as `suite` so that running the testing section will be smoother
* There are several bugs in recursive_functions/test.ml. I fixed all that I know of.